### PR TITLE
[*] CORE: Remove unused $this->export_fields

### DIFF
--- a/blocknewsletter.php
+++ b/blocknewsletter.php
@@ -69,47 +69,6 @@ class Blocknewsletter extends Module
 		{
 			$this->file = 'export_'.Configuration::get('PS_NEWSLETTER_RAND').'.csv';
 			$this->post_valid = array();
-
-			// Getting data...
-			$countries = Country::getCountries($this->context->language->id);
-
-			// ...formatting array
-			$countries_list = array($this->l('All countries'));
-			foreach ($countries as $country)
-				$countries_list[$country['id_country']] = $country['name'];
-
-			// And filling fields to show !
-			$this->fields_export = array(
-				'COUNTRY' => array(
-					'title' => $this->l('Customers\' country'),
-					'desc' => $this->l('Operate a filter on customers\' country.'),
-					'type' => 'select',
-					'value' => $countries_list,
-					'value_default' => 0
-				),
-				'SUSCRIBERS' => array(
-					'title' => $this->l('Newsletter subscribers'),
-					'desc' => $this->l('Filter newsletter subscribers.'),
-					'type' => 'select',
-					'value' => array(
-						0 => $this->l('All customers'),
-						2 => $this->l('Subscribers'),
-						1 => $this->l('Non-subscribers')
-					),
-					'value_default' => 2
-				),
-				'OPTIN' => array(
-					'title' => $this->l('Opted-in subscribers'),
-					'desc' => $this->l('Filter opted-in subscribers.'),
-					'type' => 'select',
-					'value' => array(
-						0 => $this->l('All customers'),
-						2 => $this->l('Subscribers'),
-						1 => $this->l('Non-subscribers')
-					),
-					'value_default' => 0
-				),
-			);
 		}
 	}
 


### PR DESCRIPTION
This variable seems to be unused by the module.
The query is very large and is executed for all FO pages, even though it's mean for BO form. As a results, the execution time is bumped by Xms and by 1mb RAM !! The select query could be optimized, but since it's BO I didn't make a PR.

It seems to be related to #NM-296 (I couldn't find it on Forge :()
https://github.com/PrestaShop/blocknewsletter/commit/b4dd2b249d5c5b3988ded2b0b40718e9acd6d975